### PR TITLE
Changed webroot from `web` to `public`

### DIFF
--- a/docker-compose.fpm-nginx.yml
+++ b/docker-compose.fpm-nginx.yml
@@ -8,4 +8,4 @@ services:
       - '8100:80'
     volumes:
       # Application testing
-      - ./_host-volumes/app/web:/app/web:delegated
+      - ./_host-volumes/app/public:/app/public:delegated

--- a/docs/install-application-template.md
+++ b/docs/install-application-template.md
@@ -8,7 +8,7 @@ Open in your browser
 
     http://127.0.0.1:8000
     
-When running Apache you need a configuration like the following to use `enablePrettyUrl` in `.htaccess` in your public `web` folder
+When running Apache you need a configuration like the following to use `enablePrettyUrl` in `.htaccess` in your public `public` folder
 
     RewriteEngine on
     # If a directory or a file exists, use it directly

--- a/php/image-files/etc/apache2/sites-available/000-default.conf
+++ b/php/image-files/etc/apache2/sites-available/000-default.conf
@@ -1,4 +1,4 @@
-<Directory /app/web/>
+<Directory /app/public/>
         Options Indexes FollowSymLinks
         AllowOverride All
         Require all granted
@@ -15,7 +15,7 @@
         #ServerName www.example.com
 
         ServerAdmin webmaster@localhost
-        DocumentRoot /app/web
+        DocumentRoot /app/public
 
         # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
         # error, crit, alert, emerg.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | how to run?

Now `yii-demo` package has `public` folder, not `web`. 
After mapping `public -> web` we have `web` folder into project dir that owned by `docker` user and could not be deleted by user. After mapping entrypoint folder directly from `public` to `public` this problem will be avoided