### PR TITLE
Update Dockerfile-debian

### DIFF
--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -4,27 +4,30 @@
 ARG PHP_BASE_IMAGE_VERSION
 FROM php:${PHP_BASE_IMAGE_VERSION}
 
-# Install system packages for PHP extensions recommended for Yii 2.0 Framework
+# Install system packages for PHP extensions recommended for Yii
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+# See https://github.com/mlocati/docker-php-extension-installer#supported-php-extensions
 RUN install-php-extensions \
-        soap \
-        zip \
-        curl \
         bcmath \
         exif \
-        gd \
-        iconv \
+        sockets \
+        zip \
         intl \
-        mbstring \
-        opcache \
+        gettext \
         pdo_mysql \
         pdo_pgsql \
-        imagick \
         mongodb \
+        gd \
+        imagick \
+        opcache \
         xdebug
 
 # Disable xdebug by default (see PHP_ENABLE_XDEBUG)
 RUN rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+# Install Composer
+RUN install-php-extensions @composer-2.1.3
+RUN composer clear-cache
 
 # Set default ENV variables
 ENV COMPOSER_ALLOW_SUPERUSER=1 \
@@ -47,21 +50,12 @@ RUN if [ `echo "$VERSION_XDEBUG" | grep -cE [3][.][0-9]+[.][0-9]+.*` = 1 ]; then
         rm /usr/local/etc/php/conf.d/xdebug3.ini; \
     fi
 
-# Add GITHUB_API_TOKEN support for composer
-RUN chmod 700 \
-        /usr/local/bin/docker-php-entrypoint \
-        /usr/local/bin/composer
-
-# Install composer
-RUN curl -sS https://getcomposer.org/installer | php -- \
-        --filename=composer.phar \
-        --install-dir=/usr/local/bin && \
-    composer clear-cache
+RUN chmod 700 /usr/local/bin/docker-php-entrypoint
 
 # Enable mod_rewrite for images with apache
 RUN if command -v a2enmod >/dev/null 2>&1; then \
-        a2enmod rewrite headers \
-    ;fi
+        a2enmod rewrite headers; \
+    fi
 
 # Application environment
 WORKDIR /app

--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -4,6 +4,8 @@
 ARG PHP_BASE_IMAGE_VERSION
 FROM php:${PHP_BASE_IMAGE_VERSION}
 
+RUN apt-get update
+
 # Install system packages for PHP extensions recommended for Yii
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 # See https://github.com/mlocati/docker-php-extension-installer#supported-php-extensions
@@ -29,11 +31,15 @@ RUN rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 RUN install-php-extensions @composer
 RUN composer global clear-cache
 
+RUN if [ -d /usr/local/bin/docker-php-entrypoint ]; then \
+    chmod 700 /usr/local/bin/docker-php-entrypoint; \
+    fi
+
 # Set default ENV variables
 ENV COMPOSER_ALLOW_SUPERUSER=1 \
     PHP_USER_ID=33 \
     PHP_ENABLE_XDEBUG=0 \
-    PATH=/app:/app/vendor/bin:/root/.composer/vendor/bin:$PATH \
+    PATH=/app:/app/vendor/bin:$PATH \
     TERM=linux
 
 # Install node (for asset management with foxy)
@@ -48,10 +54,6 @@ RUN if [ `echo "$VERSION_XDEBUG" | grep -cE [3][.][0-9]+[.][0-9]+.*` = 1 ]; then
         rm /usr/local/etc/php/conf.d/xdebug2.ini; \
     else \
         rm /usr/local/etc/php/conf.d/xdebug3.ini; \
-    fi
-
-RUN if [ -a /usr/local/bin/docker-php-entrypoint ]; then \
-    chmod 700 /usr/local/bin/docker-php-entrypoint; \
     fi
 
 # Enable mod_rewrite for images with apache

--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -26,7 +26,7 @@ RUN install-php-extensions \
 RUN rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # Install Composer
-RUN install-php-extensions @composer-2.1.3
+RUN install-php-extensions @composer
 RUN composer global clear-cache
 
 # Set default ENV variables

--- a/php/Dockerfile-debian
+++ b/php/Dockerfile-debian
@@ -27,7 +27,7 @@ RUN rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # Install Composer
 RUN install-php-extensions @composer-2.1.3
-RUN composer clear-cache
+RUN composer global clear-cache
 
 # Set default ENV variables
 ENV COMPOSER_ALLOW_SUPERUSER=1 \
@@ -50,7 +50,9 @@ RUN if [ `echo "$VERSION_XDEBUG" | grep -cE [3][.][0-9]+[.][0-9]+.*` = 1 ]; then
         rm /usr/local/etc/php/conf.d/xdebug3.ini; \
     fi
 
-RUN chmod 700 /usr/local/bin/docker-php-entrypoint
+RUN if [ -a /usr/local/bin/docker-php-entrypoint ]; then \
+    chmod 700 /usr/local/bin/docker-php-entrypoint; \
+    fi
 
 # Enable mod_rewrite for images with apache
 RUN if command -v a2enmod >/dev/null 2>&1; then \


### PR DESCRIPTION
Remove default/installed PHP extensions, see https://github.com/mlocati/docker-php-extension-installer#supported-php-extensions
Add PHP extensions: `sockets` and `gettext`
Install Composer via `mlocati/php-extension-installer`

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 
