### PR TITLE
Feature/stable extensions

### DIFF
--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -39,7 +39,6 @@ RUN apt-get update && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install common system packages for PHP extensions recommended for Yii 2.0 Framework
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions \
         soap-stable \
         zip-stable \

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -7,8 +7,7 @@ FROM php:${PHP_BASE_IMAGE_VERSION} as min
 # Install required system packages for PHP extensions for Yii 3.x Framework
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions \
-        intl \
-        sockets
+        intl-stable
 
 # Environment settings
 ENV PHP_USER_ID=33 \
@@ -42,17 +41,19 @@ RUN apt-get update && \
 # Install common system packages for PHP extensions recommended for Yii 2.0 Framework
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions \
-        soap \
-        zip \
-        bcmath \
-        exif \
-        gd \
-        opcache \
-        pdo_mysql \
-        pdo_pgsql \
-        imagick \
-        mongodb \
-        xdebug
+        soap-stable \
+        zip-stable \
+        bcmath-stable \
+        exif-stable \
+        gd-stable \
+        opcache-stable \
+        pdo_mysql-stable \
+        pdo_pgsql-stable \
+        imagick-stable \
+        mongodb-stable \
+        xdebug-stable \
+        sockets-stable
+
 
 COPY image-files/dev/ /
 

--- a/docs/install-extensions.md
+++ b/docs/install-extensions.md
@@ -1,5 +1,19 @@
 ## Installing additional extensions
 
+It is recommended to install additional PHP extensions with https://github.com/mlocati/docker-php-extension-installer
+
+```dockerfile
+FROM yiisoftware/yii-php:8.1-apache-min
+RUN install-php-extensions \
+        <EXTENSION_NAME>-stable
+```
+
+---
+
+## Custom installations
+
+This section is mostly deprecated and exists only for reference.
+
 ### Composer asset plugin
 
     RUN composer global require "fxp/composer-asset-plugin:^1.4.2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | see comment below
| Fixed issues  | fixes failing 8.x builds 

This change requires `stable` PHP extensions and also moves sockets to the `dev` image, as mentioned in:
https://github.com/yiisoft/yii-docker/pull/25#issuecomment-1186979850

I really think we should be as minimal as possible with the `-min` images.