### PR TITLE
build images for amd64 and arm64 platform (for Apple Silicon, M1, M2)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -95,7 +95,9 @@ jobs:
         set: |
           *.platform=linux/amd64
     - name: Build and push docker image (arm64)
-      if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' && github.event_name == 'workflow_dispatch'
+      if: |
+          (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master') &&
+          (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
       uses: docker/bake-action@v2
       with:
         files: docker-compose.yml

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -93,4 +93,12 @@ jobs:
         files: docker-compose.yml
         push: true
         set: |
-          *.platform=linux/amd64,linux/arm64
+          *.platform=linux/amd64
+    - name: Build and push docker image (arm64)
+      if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' && ${{ github.event_name == 'workflow_dispatch' }}
+      uses: docker/bake-action@v2
+      with:
+        files: docker-compose.yml
+        push: true
+        set: |
+          *.platform=linux/arm64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,7 +37,14 @@ jobs:
       DOCKERFILE_FLAVOUR: ${{ matrix.dockerfile-flavour }}
       COMPOSE_FILE: ${{ matrix.compose-file }}
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: 'amd64,arm64'
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Set version suffix
       if: startsWith(github.ref, 'refs/tags/')
       run: echo "PHP_IMAGE_VERSION_SUFFIX=-${GITHUB_REF:10}" >> $GITHUB_ENV
@@ -55,7 +62,12 @@ jobs:
         docker info
         docker-compose version
     - name: Build Image
-      run: docker-compose build --build-arg X_LEGACY_GD_LIB=$X_LEGACY_GD_LIB
+      uses: docker/bake-action@v2
+      with:
+        files: docker-compose.yml
+        load: true
+        set: |
+          *.platform=linux/amd64
     - name: Test PHP version and Xdebug only loaded by ENV
       run: |
         docker-compose run --rm php-min php -v -- | grep "Xdebug" && exit 5
@@ -70,10 +82,15 @@ jobs:
           docker images
     - name: Login to Docker
       if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_PASS }}
-    - name: Push docker image
+    - name: Build and push docker image
       if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master'
-      run: docker-compose push
+      uses: docker/bake-action@v2
+      with:
+        files: docker-compose.yml
+        push: true
+        set: |
+          *.platform=linux/amd64,linux/arm64

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -95,7 +95,7 @@ jobs:
         set: |
           *.platform=linux/amd64
     - name: Build and push docker image (arm64)
-      if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' && ${{ github.event_name == 'workflow_dispatch' }}
+      if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' && github.event_name == 'workflow_dispatch'
       uses: docker/bake-action@v2
       with:
         files: docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
 version: '2'
+
+networks:
+    default:
+
 services:
 
     php-min:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | it builds images for amd64 and arm64

I saw it late, there is another PR (#31 ) which resolves this issue. Mine is different, because I used the native docker actions, not directly the buildx command.

The tests runs only for amd64, that is why it is fast. The master builds lasts for 1 hour both for amd64 and arm64.

Since I made it for the other repository (https://github.com/yiisoft/yii2-docker/pull/161), I updated this, with the same modifications.

Images are pushed to here: https://hub.docker.com/repository/docker/albertborsos/yii-php/general

I tested, it works.
